### PR TITLE
Allow enforce http client faking

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -95,6 +95,13 @@ class Factory
     protected $responseSequences = [];
 
     /**
+     * Require requests to have a fake stub.
+     *
+     * @var bool
+     */
+    protected $enforceFaking = false;
+
+    /**
      * Create a new factory instance.
      *
      * @param  \Illuminate\Contracts\Events\Dispatcher|null  $dispatcher
@@ -218,6 +225,30 @@ class Factory
                         ? $callback($request, $options)
                         : $callback;
         });
+    }
+
+    /**
+     * Require requests to have a fake stub.
+     *
+     * @return $this
+     */
+    public function enforceFaking()
+    {
+        $this->enforceFaking = true;
+
+        return $this;
+    }
+
+    /**
+     * Do not require requests to have a fake stub.
+     *
+     * @return $this
+     */
+    public function dontEnforceFaking()
+    {
+        $this->enforceFaking = false;
+
+        return $this;
     }
 
     /**
@@ -390,7 +421,7 @@ class Factory
         }
 
         return tap($this->newPendingRequest(), function ($request) {
-            $request->stub($this->stubCallbacks);
+            $request->stub($this->stubCallbacks)->enforceFaking($this->enforceFaking);
         })->{$method}(...$parameters);
     }
 }

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -44,6 +44,7 @@ use Illuminate\Http\Client\Factory;
  * @method static \Illuminate\Http\Client\Response post(string $url, array $data = [])
  * @method static \Illuminate\Http\Client\Response put(string $url, array $data = [])
  * @method static \Illuminate\Http\Client\Response send(string $method, string $url, array $options = [])
+ * @method static \Illuminate\Http\Client\Factory dontEnforceFaking()
  * @method static void assertSent(callable $callback)
  * @method static void assertSentInOrder(array $callbacks)
  * @method static void assertNotSent(callable $callback)
@@ -104,6 +105,18 @@ class Http extends Facade
     {
         return tap(static::getFacadeRoot(), function ($fake) use ($url, $callback) {
             static::swap($fake->stubUrl($url, $callback));
+        });
+    }
+
+    /**
+     * Require requests to have a fake stub.
+     *
+     * @return \Illuminate\Http\Client\Factory
+     */
+    public static function enforceFaking()
+    {
+        return tap(static::getFacadeRoot(), function ($fake) {
+            static::swap($fake->enforceFaking());
         });
     }
 }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -25,6 +25,7 @@ use Mockery as m;
 use OutOfBoundsException;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 use Symfony\Component\VarDumper\VarDumper;
 
 class HttpClientTest extends TestCase
@@ -1526,5 +1527,22 @@ class HttpClientTest extends TestCase
         $response = $this->factory->get('http://foo.com/api')->throwIf(false);
 
         $this->assertSame('{"result":{"foo":"bar"}}', $response->body());
+    }
+
+    public function testItCanEnforceFaking()
+    {
+        $this->factory->enforceFaking();
+        $this->factory->fake(['https://vapor.laravel.com' => Factory::response('ok', 200)]);
+        $this->factory->fake(['https://forge.laravel.com' => Factory::response('ok', 200)]);
+
+        $responses = [];
+        $responses[] = $this->factory->get('https://vapor.laravel.com')->body();
+        $responses[] = $this->factory->get('https://forge.laravel.com')->body();
+        $this->assertSame(['ok', 'ok'], $responses);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Attempted request to [https://laravel.com] without a matching fake.');
+
+        $this->factory->get('https://laravel.com');
     }
 }

--- a/tests/Support/SupportFacadesHttpTest.php
+++ b/tests/Support/SupportFacadesHttpTest.php
@@ -48,4 +48,11 @@ class SupportFacadesHttpTest extends TestCase
         $factory = $this->app->make(Factory::class);
         $this->assertSame('OK!', $factory->get('https://laravel.com')->body());
     }
+
+    public function testFacadeRootIsSharedWhenEnforcingFaking(): void
+    {
+        $client = Http::enforceFaking();
+
+        $this->assertSame($client, $this->app->make(Factory::class));
+    }
 }


### PR DESCRIPTION
## Purpose

This PR aims to bring the ability for developers to force any requests made via the Http client to be faked / stubbed.

## Why this feature is useful

This feature it useful in a test suite. I've often wanted the ability to throw an exception when a request made via the Http client was not faked. This serves as a reminder to the develop that they have missed something as I've seen it be common in a test suite that real requests are still being made to services that should have been faked.

These are often only detected when then service API is down, you hit rate limits (due to the test suite), or you notice that a specific test hangs while making the request.

## Usage

This new feature could be used in _any_ `TestCase::setUp()` method.

```php
/* ... */

use Illuminate\Support\Facades\Http;

abstract class TestCase extends BaseTestCase
{
    use CreatesApplication;

    protected function setUp(): void
    {
        parent::setUp();

        Http::enforceFaking();
    }

}
```

Any request made that is not "faked" will now throw an exception.

```php
public function testItDoesTheThingWithoutFaking(): void
{
    $this->post('endpoint-that-utilises-the-http-facade');

   // RuntimeException: Attempted request to [https://acme.com] without a matching fake.

   /* ... */
}

public function testItDoesTheThingWith(): void
{
    Http::fake(['https://acme.com' => Http::response('ok')]);

    $response = $this->post('endpoint-that-utilises-the-http-facade');

   // no exception thrown...

   /* ... */
}

```

Once this feature has been turned on it is still possible to disable it for a specific test...

```php
public function testItDoesTheThingWithoutFaking(): void
{
    Http::dontEnforceFaking();

    $this->post('endpoint-that-utilises-the-http-facade');

   // no exception thrown...

   /* ... */
}
```

## Naming

I'm not in love the naming here tbh. I went with "fake" rather than stub as that is mostly the wording used for the current developer facing things. Feedback welcomed.

## Using existing features

Unfortunately we are unable to utilise the existing faking functionality to achieve this due to precedence.

#### Http::fake(Closure);

```php
// in the test setUp...

Http::fake(fn () => throw new Exception('Need to fake.'));

// in the test...

Http::fake(['https://acme.com' => Http::response('ok')]);

Http::get('https://acme.com');

// Exception: Need to fake.
```

#### Http::fake(array);

```php
// in the test setUp...

Http::fake(['*' => fn () => throw new Exception('Need to fake.')]);

// in the test...

Http::fake(['https://acme.com' => Http::response('ok')]);

Http::get('https://acme.com');

// Exception: Need to fake.
```

## Further considerations

### Provide a handler

It is possible to allow the developer to "handle" requests that have not been faked. I did not add this feature as I'm not sure of a use-case other than to throw an exception and didn't see any value in allowing the developer to adjust the exception thrown in the test suite.

This is why I landed on a simple "flag" approach rather than a handler approach. Would love feedback from everyone on this though.

### "without" style method

A lot of the testing helpers in Laravel are provided via the `$this->withoutWhatever()` style methods. I did not add this as I think that most of the Facade style faking is usually achieved on the Facade itself. What's more is that this is not a global change due to the fact that the  service provider binds a Http client, but instead the Facade holds a static instance. If you ask the container to make a Factory, this won't be applied, which feels unexpected to me.

```php
Http::enforeFaking();

$factory = $this->app[\Illuminate\Http\Client\Factory::class];

// $factory will not enforce faking.
```