### PR TITLE
allow context to be shared across channels and stacks

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -52,6 +52,13 @@ class LogManager implements LoggerInterface
     protected $dateFormat = 'Y-m-d H:i:s';
 
     /**
+     * The context shared across channels and stacks.
+     *
+     * @var array
+     */
+    protected $sharedContext = [];
+
+    /**
      * Create a new Log manager instance.
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
@@ -84,10 +91,10 @@ class LogManager implements LoggerInterface
      */
     public function stack(array $channels, $channel = null)
     {
-        return new Logger(
+        return (new Logger(
             $this->createStackDriver(compact('channels', 'channel')),
             $this->app['events']
-        );
+        ))->withContext($this->sharedContext);
     }
 
     /**
@@ -123,7 +130,7 @@ class LogManager implements LoggerInterface
     {
         try {
             return $this->channels[$name] ?? with($this->resolve($name, $config), function ($logger) use ($name) {
-                return $this->channels[$name] = $this->tap($name, new Logger($logger, $this->app['events']));
+                return $this->channels[$name] = $this->tap($name, new Logger($logger, $this->app['events']))->withContext($this->sharedContext);
             });
         } catch (Throwable $e) {
             return tap($this->createEmergencyLogger(), function ($logger) use ($e) {
@@ -507,6 +514,33 @@ class LogManager implements LoggerInterface
         if (isset($this->channels[$driver])) {
             unset($this->channels[$driver]);
         }
+    }
+
+    /**
+     * Share context across channels and stacks.
+     *
+     * @param  array  $context
+     * @return $this
+     */
+    public function shareContext(array $context)
+    {
+        foreach ($this->channels as $channel) {
+            $channel->withContext($context);
+        }
+
+        $this->sharedContext = array_merge($this->sharedContext, $context);
+
+        return $this;
+    }
+
+    /**
+     * The context shared across channels and stacks.
+     *
+     * @return array
+     */
+    public function sharedContext()
+    {
+        return $this->sharedContext;
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Log.php
+++ b/src/Illuminate/Support/Facades/Log.php
@@ -8,6 +8,8 @@ namespace Illuminate\Support\Facades;
  * @method static \Psr\Log\LoggerInterface build(array $config)
  * @method static \Illuminate\Log\Logger withContext(array $context = [])
  * @method static \Illuminate\Log\Logger withoutContext()
+ * @method static \Illuminate\Log\LogManager shareContext(array $context)
+ * @method static array sharedContext()
  * @method static void alert(string $message, array $context = [])
  * @method static void critical(string $message, array $context = [])
  * @method static void debug(string $message, array $context = [])


### PR DESCRIPTION
## Purpose

This PR bring the ability to share context across all channels and stacks, rather than just one.

## Why this feature is useful

Currently when we specify context, it is on a per log or per channel basis.

```php
// per log...

Log::info('per log', ['log' => 'context']);

// per channel...

Log::withContext(['channel' => 'context']);

Log::channel('stderr')->withContext(['channel' => 'context']);
```

but there is no way to specify context to be shared across all channels and stacks.

This feature is useful in the example [currently shown in the docs](https://laravel.com/docs/9.x/logging#contextual-information) for the `withContext` feature of a channel.

The example in the docs being...

```php
class AssignRequestId
{
    /**
     * Handle an incoming request.
     *
     * @param  \Illuminate\Http\Request  $request
     * @param  \Closure  $next
     * @return mixed
     */
    public function handle($request, Closure $next)
    {
        $requestId = (string) Str::uuid();
 
        Log::withContext([
            'request-id' => $requestId
        ]);
 
        return $next($request)->header('Request-Id', $requestId);
    }
}

```

The problem with this is that it only applies the context the the default channel, but it would be useful if the context was shared across ALL channels and stacks.

## Usage

This new feature could be used in a middleware as above, but also in a service provider to apply a unique ID to all invocations of the app, be it from a request or a job or an artisan command.

```php
class AppServiceProvider
{
    public function register()
    {
        //
    }


    public function boot()
    {
        Log::shareContext([
            'invocation-id' => Str::uuid(),
        ]);
    }
}
```

Now in my application, no matter what logger I use, I'll have the invocation ID in my context.

```php
Log::info(/* ... */);

Log::channel('stderr')->info(/* ... */);

Log::channel('bugsnag')->info(/* ... */);
```

Other logging systems outside of the Laravel logging system can also hook in and get the shared context to utilise...

```php
$sharedContext = Log::sharedContext();
```


## Notes

- Not doing anything to the emergency logger. One I couldn't test it, and two if there is something funky happening with the context that is causing the initial logger to fail creation I wouldn't want that to also apply to the emergency logger.
- Stacks get the shared context at the time they are created, but do not get any additional shared context once resolved - where as channels will always have the latest shared context.
- Merging is performed in the same manner as `withContext` i.e. not recursive.