### PR TITLE
create attachable interface and add Mail\Message support

### DIFF
--- a/src/Illuminate/Contracts/Mail/Attachable.php
+++ b/src/Illuminate/Contracts/Mail/Attachable.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Contracts\Mail;
+
+interface Attachable
+{
+    /**
+     * @return \Illuminate\Mail\Attachment
+     */
+    public function toMailAttachment();
+}

--- a/src/Illuminate/Mail/Attachment.php
+++ b/src/Illuminate/Mail/Attachment.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Illuminate\Mail;
+
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
+use Illuminate\Support\Traits\Macroable;
+
+class Attachment
+{
+    use Macroable;
+
+    /**
+     * The attached file's filename.
+     *
+     * @var string|null
+     */
+    protected $as;
+
+    /**
+     * The attached file's mime type.
+     *
+     * @var string|null
+     */
+    protected $mime;
+
+    /**
+     * Attaches the attachment to the mail message.
+     *
+     * @var \Closure
+     */
+    protected $attacher;
+
+    /**
+     * Create a mail attachment.
+     *
+     * @param  \Closure  $attacher
+     */
+    private function __construct($attacher)
+    {
+        $this->attacher = $attacher;
+    }
+
+    /**
+     * Create a mail attachment from a file on disk.
+     *
+     * @param  string  $file
+     * @return static
+     */
+    public static function fromPath($file)
+    {
+        return new static(fn ($message, $attachment) => $message->attach(
+            $file, ['as' => $attachment->as, 'mime' => $attachment->mime]
+        ));
+    }
+
+    /**
+     * Create a mail attachment from a file in the default storage disk.
+     *
+     * @param  string  $path
+     * @return static
+     */
+    public static function fromStorage($path)
+    {
+        return static::fromStorageDisk(null, $path);
+    }
+
+    /**
+     * Create a mail attachment from a file in the specified storage disk.
+     *
+     * @param  string  $disk
+     * @param  string  $path
+     * @return static
+     */
+    public static function fromStorageDisk($disk, $path)
+    {
+        return new static(function ($message, $attachment) use ($disk, $path) {
+            $storage = Container::getInstance()->make(
+                FilesystemFactory::class
+            )->disk($disk);
+
+            $message->attachData(
+                $storage->get($path),
+                $attachment->as ?? basename($path),
+                ['mime' => $attachment->mime ?? $storage->mimeType($path)]
+            );
+        });
+    }
+
+    /**
+     * Create a mail attachment from in-memory data.
+     *
+     * @param  string|\Closure  $data
+     * @param  string  $name
+     * @return static
+     */
+    public static function fromData($data, $name)
+    {
+        return (new static(fn ($message, $attachment) => $message->attachData(
+            value($data), $attachment->as, ['mime' => $attachment->mime]
+        )))->as($name);
+    }
+
+    /**
+     * Set the attached file's filename.
+     *
+     * @param  string  $name
+     */
+    public function as($name)
+    {
+        $this->as = $name;
+
+        return $this;
+    }
+
+    /**
+     * Set the attached file's mime type.
+     *
+     * @param  string  $mime
+     */
+    public function withMime($mime)
+    {
+        $this->mime = $mime;
+
+        return $this;
+    }
+
+    /**
+     * Attach the file to the message.
+     *
+     * @param  mixed  $message
+     */
+    public function attachTo($message)
+    {
+        return tap($message, fn ($message) => ($this->attacher)($message, $this));
+    }
+}

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -4,6 +4,7 @@ namespace Illuminate\Mail;
 
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
+use Illuminate\Contracts\Mail\Attachable;
 use Illuminate\Contracts\Mail\Factory as MailFactory;
 use Illuminate\Contracts\Mail\Mailable as MailableContract;
 use Illuminate\Contracts\Queue\Factory as Queue;
@@ -867,12 +868,20 @@ class Mailable implements MailableContract, Renderable
     /**
      * Attach a file to the message.
      *
-     * @param  string  $file
+     * @param  string|\Illuminate\Contracts\Mail\Attachable|\Illuminate\Mail\Attachment  $file
      * @param  array  $options
      * @return $this
      */
     public function attach($file, array $options = [])
     {
+        if ($file instanceof Attachable) {
+            $file = $file->toMailAttachment();
+        }
+
+        if ($file instanceof Attachment) {
+            return $file->attachTo($this);
+        }
+
         $this->attachments = collect($this->attachments)
                     ->push(compact('file', 'options'))
                     ->unique('file')

--- a/src/Illuminate/Mail/Message.php
+++ b/src/Illuminate/Mail/Message.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Mail;
 
+use Illuminate\Contracts\Mail\Attachable;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Symfony\Component\Mime\Address;
@@ -290,12 +291,20 @@ class Message
     /**
      * Attach a file to the message.
      *
-     * @param  string  $file
+     * @param  string|\Illuminate\Contracts\Mail\Attachable|\Illuminate\Mail\Attachment  $file
      * @param  array  $options
      * @return $this
      */
     public function attach($file, array $options = [])
     {
+        if ($file instanceof Attachable) {
+            $file = $file->toMailAttachment();
+        }
+
+        if ($file instanceof Attachment) {
+            return $file->attachTo($this);
+        }
+
         $this->message->attachFromPath($file, $options['as'] ?? null, $options['mime'] ?? null);
 
         return $this;

--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -3,8 +3,10 @@
 namespace Illuminate\Notifications\Messages;
 
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Mail\Attachable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Renderable;
+use Illuminate\Mail\Attachment;
 use Illuminate\Mail\Markdown;
 use Illuminate\Support\Traits\Conditionable;
 
@@ -241,12 +243,20 @@ class MailMessage extends SimpleMessage implements Renderable
     /**
      * Attach a file to the message.
      *
-     * @param  string  $file
+     * @param  string|\Illuminate\Contracts\Mail\Attachable|\Illuminate\Contracts\Mail\Attachable  $file
      * @param  array  $options
      * @return $this
      */
     public function attach($file, array $options = [])
     {
+        if ($file instanceof Attachable) {
+            $file = $file->toMailAttachment();
+        }
+
+        if ($file instanceof Attachment) {
+            return $file->attachTo($this);
+        }
+
         $this->attachments[] = compact('file', 'options');
 
         return $this;

--- a/tests/Integration/Mail/AttachingFromStorageTest.php
+++ b/tests/Integration/Mail/AttachingFromStorageTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Mail;
+
+use Illuminate\Support\Facades\Storage;
+use Orchestra\Testbench\TestCase;
+use Illuminate\Mail\Attachment;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Support\Facades\File;
+
+class AttachingFromStorageTest extends TestCase
+{
+    public function testItCanAttachFromStorage()
+    {
+        Storage::disk('local')->put('/dir/foo.png', 'expected body contents');
+        $mail = new MailMessage();
+        $attachment = Attachment::fromStorageDisk('local', '/dir/foo.png')
+            ->as('bar')
+            ->withMime('text/css');
+
+        $attachment->attachTo($mail);
+
+        $this->assertSame([
+            'data' => 'expected body contents',
+            'name' => 'bar',
+            'options' => [
+                'mime' => 'text/css',
+            ],
+        ], $mail->rawAttachments[0]);
+
+        Storage::disk('local')->delete('/dir/foo.png');
+   }
+
+    public function testItCanAttachFromStorageAndFallbackToStorageNameAndMime()
+    {
+        Storage::disk()->put('/dir/foo.png', 'expected body contents');
+        $mail = new MailMessage();
+        $attachment = Attachment::fromStorageDisk('local', '/dir/foo.png');
+
+        $attachment->attachTo($mail);
+
+        $this->assertSame([
+            'data' => 'expected body contents',
+            'name' => 'foo.png',
+            'options' => [
+                'mime' => 'image/png',
+            ],
+        ], $mail->rawAttachments[0]);
+
+        Storage::disk('local')->delete('/dir/foo.png');
+   }
+}

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -2,7 +2,9 @@
 
 namespace Illuminate\Tests\Mail;
 
+use Illuminate\Contracts\Mail\Attachable;
 use Illuminate\Contracts\View\Factory;
+use Illuminate\Mail\Attachment;
 use Illuminate\Mail\Mailable;
 use Illuminate\Mail\Mailer;
 use Illuminate\Mail\Transport\ArrayTransport;
@@ -493,6 +495,97 @@ class MailMailableTest extends TestCase
         $this->assertSame('hello@laravel.com', $sentMessage->getEnvelope()->getRecipients()[0]->getAddress());
         $this->assertStringContainsString('X-Tag: test', $sentMessage->toString());
         $this->assertStringContainsString('X-Tag: foo', $sentMessage->toString());
+    }
+
+    public function testItAttachesFilesViaAttachableContractFromPath()
+    {
+        $mailable = new WelcomeMailableStub;
+
+        $mailable->attach(new class() implements Attachable {
+            public function toMailAttachment()
+            {
+                return Attachment::fromPath(__DIR__.'/foo.jpg')
+                    ->as('bar')
+                    ->withMime('image/jpeg');
+            }
+        });
+
+        $this->assertSame([
+            'file' => __DIR__.'/foo.jpg',
+            'options' => [
+                'as' => 'bar',
+                'mime' => 'image/jpeg',
+            ]
+        ], $mailable->attachments[0]);
+    }
+
+    public function testItAttachesFilesViaAttachableContractFromData()
+    {
+        $mailable = new WelcomeMailableStub;
+
+        $mailable->attach(new class() implements Attachable {
+            public function toMailAttachment()
+            {
+                return Attachment::fromData('expected attachment body', 'foo.jpg')
+                    ->as('bar')
+                    ->withMime('image/jpeg');
+            }
+        });
+
+        $this->assertSame([
+            'data' => 'expected attachment body',
+            'name' => 'bar',
+            'options' => [
+                'mime' => 'image/jpeg',
+            ]
+        ], $mailable->rawAttachments[0]);
+    }
+
+    public function testItAttachesFilesViaAttachableContractFromDataWithClosure()
+    {
+        $mailable = new WelcomeMailableStub;
+
+        $mailable->attach(new class() implements Attachable {
+            public function toMailAttachment()
+            {
+                return Attachment::fromData(fn () => 'expected attachment body', 'foo.jpg')
+                    ->as('bar')
+                    ->withMime('image/jpeg');
+            }
+        });
+
+        $this->assertSame([
+            'data' => 'expected attachment body',
+            'name' => 'bar',
+            'options' => [
+                'mime' => 'image/jpeg',
+            ]
+        ], $mailable->rawAttachments[0]);
+    }
+
+    public function testItAttachesFilesViaAttachableContractFromMacroConstructor()
+    {
+        Attachment::macro('fromInvoice', function ($name) {
+            return Attachment::fromData(fn () => 'pdf content', $name);
+        });
+        $mailable = new WelcomeMailableStub;
+
+        $mailable->attach(new class() implements Attachable {
+            public function toMailAttachment()
+            {
+                return Attachment::fromInvoice('foo')
+                    ->as('bar')
+                    ->withMime('image/jpeg');
+            }
+        });
+
+        $this->assertSame([
+            'data' => 'pdf content',
+            'name' => 'bar',
+            'options' => [
+                'mime' => 'image/jpeg',
+            ]
+        ], $mailable->rawAttachments[0]);
     }
 }
 


### PR DESCRIPTION
## Purpose

This PR bring the the concept of an "Attachable" for re-use of attaching files to a mail. It also standardises the attachable features across:

- `Illuminate/Mail/Mailable`
- `Illuminate/Mail/Message`
- `Illuminate/Notifications/Messages/MailMessage`

which is currently inconsistent, with `Mailable` supporting attaching from storage, and the others not.

## Why this feature is useful

Often in applications you have a model or POPO that represents a "file". The best of example of this is the ever classic example of an `Invoice`. You may have in invoice model in your system that you want to attach to emails (or other notifications, more on that later). There may be several emails that you want to attach invoices too, and what's more is you might have some extra logic involved in retrieving the invoice before attaching to an email.

Currently we can attach files to an email in the following ways...

```php
class InvoiceCreated extends Mailable
{
    public function __construct(private Invoice $invoice)
    {
        //
    }

    public function build()
    {
        // From a file on the local filesystem...

        $this->attach($this->invoice->path);

        // As above, but with a nice filename and specifying the mime type...

        $this->attach($this->invoice->path, [
            'as' => "Acme Invoice {$this->invoice->number}.pdf",
            'mime' => 'application/pdf',
        ]);

        // From in-memory data...

        $this->attachData(
            $this->invoice->content,
            "Acme Invoice {$this->invoice->number}.pdf",
            ['mime' => 'application/pdf']
        );

        // Getting the contents on the fly...

        $data = Http::withHeaders(['Accept' => 'application/pdf'])
            ->get("https://api.xero.com/api.xro/2.0/Invoices/{$this->invoice->xero_id}")
            ->throw()
            ->body();

        $this->attachData(
            $data,
            "Acme Invoice {$this->invoice->number}.pdf",
            ['mime' => 'application/pdf']
        );


        /*
         * The following are only available on the `Mailable` class, making the API inconsistent...
         */

        // From the default storage disk...

        $this->attachFromStorage(
            $this->invoice->path,
            "Acme Invoice {$this->invoice->number}.pdf",
            ['mime' => 'application/pdf']
        );

        // From a specific storage disk...

        $this->attachFromStorageDisk(
            'backblaze',
            $this->invoice->file_path,
            "Acme Invoice {$this->invoice->number}.pdf",
            ['mime' => 'application/pdf']
        );
    }
}

```

When you then implement another email that sends this same file, you may then find yourself duplicating this code.

This PR aims to improve experience of attaching files to an email or other notification system.

## Usage

There is now an new contract called `Illumiante\Contracts\Mail\Attachable` and a new `Illuminate\Mail\Attachment` class.

You can specify how you want your attachment to be attached to you mail / notification...

```php
class Invoice extends Model implements Attachable
{
    public function toMailAttachment()
    {
        // From a file on the local filesystem...

        return Attachment::fromPath($this->path);

        // As above, but with a nice filename and specifying the mime type...

        return Attachment::fromPath($this->path)
            ->as("Acme Invoice {$this->number}.pdf")
            ->withMime('application/pdf');

        // From in-memory data...

        return Attachment::fromData($this->content)
            ->as("Acme Invoice {$this->number}.pdf")
            ->withMime('application/pdf');

        // Getting the contents on the fly...

        return Attachment::fromData(fn () => Http::withHeaders(['Accept' => 'application/pdf'])
            ->get("https://api.xero.com/api.xro/2.0/Invoices/{$this->xero_id}")
            ->throw()
            ->body()
        )->as("Acme Invoice {$this->invoice->number}.pdf")->withMime('application/pdf');
 

        /*
         * The following are now available on the `Mailable` and mail messages, both mail and notifications
         * making the API consistent 🎉
         */


        // From the default storage disk...

        return Attachment::fromStorage($this->path)
            ->as("Acme Invoice {$this->number}.pdf")
            ->withMime('application/pdf');

        // From a specific storage disk...

        return Attachment::fromStorageDisk('backblaze', $this->path)
            ->as("Acme Invoice {$this->number}.pdf")
            ->withMime('application/pdf');
    }
}
```

Then to attach a the invoice the mailable, no matter how it is sourced (from path, from data, from storage, etc) the following API is used in the mailable...

```php
class InvoiceCreated extends Mailable
{
    public function __construct(private Invoice $invoice)
    {
        //
    }

    public function build()
    {
        $this->attach($this->invoice);
    }
}
```

It is also possible to set the filename or mine from within the mailable itself...

```php
class InvoiceCreated extends Mailable
{
    public function __construct(private Invoice $invoice)
    {
        //
    }

    public function build()
    {
        $this->attach(
            $this->invoice->toMailAttachment()->as('Invoice.pdf')
        );
    }
}
```

## General API

This new class has two ways of attaching data. By referencing a local file or by supplying a string of contents. All APIs are just wrappers around these two features.

This means that this could be extended to not only work for Emails, but also for Notifications in general - be it Slack notifications or Telegram notifications etc.

To support the new class, you would do a similar change to the attachment API as seen here: https://github.com/timacdonald/framework/pull/10/files#diff-76badd2790802d269067aad1c57c3eb75a83f0f8e3bddbb53db5832c818a4603

Then you would ensure your class has a `attach($file, array $options)` and `attachData($data, $name, array $options)` API, just like the `Mailable` class does, and you can now support the new Attachment class in 3rd party messaging implementations.

### Extended API

The attachment class is also Macroable, so it is possible to create nice named constructors from 3rd party libraries...


```php
// Service provider...

Attachment::macro('fromXeroInvoice', function ($id) {
    return Attachment::fromData(fn () => Http::withHeaders(['Accept' => 'application/pdf'])
        ->get("https://api.xero.com/api.xro/2.0/Invoices/{$id}")
        ->throw()
        ->body();
});

// Attachable...

public function toMailAttachment()
{
    return Attachment::fromXeroInvoice($this->xero_id)
        ->as("Acme Invoice {$this->number}.pdf")
        ->withMime('application/pdf');;
}
```

## Notes

- I've put the new contract and the new Attachment class in the `Mail` namespace, but as shown above it is kinda just generic "Notification" attachment, assuming you support the implicit API (which we could make explicit if we wanted). I'm happy to move it to the `Notifications` namespace if we feel that is a better fit.
- This new implementation does not dedupe the attachments, as the current Mailable implementation does.