### PR TITLE
Authorization 404 response

### DIFF
--- a/src/Illuminate/Auth/Access/AuthorizationException.php
+++ b/src/Illuminate/Auth/Access/AuthorizationException.php
@@ -15,6 +15,13 @@ class AuthorizationException extends Exception
     protected $response;
 
     /**
+     * The HTTP response status code.
+     *
+     * @var int|null
+     */
+    protected $status;
+
+    /**
      * Create a new authorization exception instance.
      *
      * @param  string|null  $message
@@ -53,12 +60,45 @@ class AuthorizationException extends Exception
     }
 
     /**
+     * Set the HTTP response status code.
+     *
+     * @param  int|null  $status
+     * @return $this
+     */
+    public function withStatus($status)
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    /**
+     * Determine if the HTTP status code has been set.
+     *
+     * @return bool
+     */
+    public function hasStatus()
+    {
+        return $this->status !== null;
+    }
+
+    /**
+     * Get the HTTP status code.
+     *
+     * @return int|null
+     */
+    public function status()
+    {
+        return $this->status;
+    }
+
+    /**
      * Create a deny response object from this exception.
      *
      * @return \Illuminate\Auth\Access\Response
      */
     public function toResponse()
     {
-        return Response::deny($this->message, $this->code);
+        return Response::deny($this->message, $this->code)->withStatus($this->status);
     }
 }

--- a/src/Illuminate/Auth/Access/HandlesAuthorization.php
+++ b/src/Illuminate/Auth/Access/HandlesAuthorization.php
@@ -27,4 +27,17 @@ trait HandlesAuthorization
     {
         return Response::deny($message, $code);
     }
+
+    /**
+     * Deny with a HTTP status code.
+     *
+     * @param  int  $status
+     * @param  ?string  $message
+     * @param  ?int  $code
+     * @return \Illuminate\Auth\Access\Response
+     */
+    public function denyWithStatus($status, $message = null, $code = null)
+    {
+        return Response::denyWithStatus($status, $message, $code);
+    }
 }

--- a/src/Illuminate/Auth/Access/Response.php
+++ b/src/Illuminate/Auth/Access/Response.php
@@ -28,6 +28,13 @@ class Response implements Arrayable
     protected $code;
 
     /**
+     * The HTTP response status code.
+     *
+     * @var int|null
+     */
+    protected $status;
+
+    /**
      * Create a new response.
      *
      * @param  bool  $allowed
@@ -64,6 +71,19 @@ class Response implements Arrayable
     public static function deny($message = null, $code = null)
     {
         return new static(false, $message, $code);
+    }
+
+    /**
+     * Create a new "deny" Response with a HTTP status code.
+     *
+     * @param  int  $status
+     * @param  string|null  $message
+     * @param  mixed  $code
+     * @return \Illuminate\Auth\Access\Response
+     */
+    public static function denyWithStatus($status, $message = null, $code = null)
+    {
+        return static::deny($message, $code)->withStatus($status);
     }
 
     /**
@@ -117,10 +137,34 @@ class Response implements Arrayable
     {
         if ($this->denied()) {
             throw (new AuthorizationException($this->message(), $this->code()))
-                        ->setResponse($this);
+                ->setResponse($this)
+                ->withStatus($this->status);
         }
 
         return $this;
+    }
+
+    /**
+     * Set the HTTP response status code.
+     *
+     * @param  null|int  $status
+     * @return $this
+     */
+    public function withStatus($status)
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    /**
+     * Get the HTTP status code.
+     *
+     * @return int|null
+     */
+    public function status()
+    {
+        return $this->status;
     }
 
     /**

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -375,7 +375,8 @@ class Handler implements ExceptionHandlerContract
         return match (true) {
             $e instanceof BackedEnumCaseNotFoundException => new NotFoundHttpException($e->getMessage(), $e),
             $e instanceof ModelNotFoundException => new NotFoundHttpException($e->getMessage(), $e),
-            $e instanceof AuthorizationException => new AccessDeniedHttpException($e->getMessage(), $e),
+            $e instanceof AuthorizationException && $e->hasStatus() => new HttpException($e->status(), $e->getMessage(), $e),
+            $e instanceof AuthorizationException && ! $e->hasStatus() => new AccessDeniedHttpException($e->getMessage(), $e),
             $e instanceof TokenMismatchException => new HttpException(419, $e->getMessage(), $e),
             $e instanceof SuspiciousOperationException => new NotFoundHttpException('Bad hostname provided.', $e),
             $e instanceof RecordsNotFoundException => new NotFoundHttpException('Not found.', $e),

--- a/tests/Auth/AuthAccessResponseTest.php
+++ b/tests/Auth/AuthAccessResponseTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Auth;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\Access\Response;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class AuthAccessResponseTest extends TestCase
 {
@@ -33,6 +34,36 @@ class AuthAccessResponseTest extends TestCase
         $response = Response::deny();
 
         $this->assertNull($response->message());
+    }
+
+    public function testItSetsEmptyStatusOnExceptionWhenAuthorizing()
+    {
+        try {
+            Response::deny()->authorize();
+            $this->fail();
+        } catch (AuthorizationException $e) {
+            $this->assertNull($e->status());
+            $this->assertFalse($e->hasStatus());
+        }
+    }
+
+    public function testItSetsStatusOnExceptionWhenAuthorizing()
+    {
+        try {
+            Response::deny()->withStatus(404)->authorize();
+            $this->fail();
+        } catch (AuthorizationException $e) {
+            $this->assertSame(404, $e->status());
+            $this->assertTrue($e->hasStatus());
+        }
+
+        try {
+            Response::denyWithStatus(404)->authorize();
+            $this->fail();
+        } catch (AuthorizationException $e) {
+            $this->assertSame(404, $e->status());
+            $this->assertTrue($e->hasStatus());
+        }
     }
 
     public function testAuthorizeMethodThrowsAuthorizationExceptionWhenResponseDenied()

--- a/tests/Integration/Foundation/ExceptionHandlerTest.php
+++ b/tests/Integration/Foundation/ExceptionHandlerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation;
+
+use Closure;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Auth\Access\Response;
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Contracts\Routing\UrlRoutable;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Tests\Integration\Auth\User;
+use Orchestra\Testbench\Exceptions\Handler;
+use Orchestra\Testbench\TestCase;
+use Throwable;
+
+class ExceptionHandlerTest extends TestCase
+{
+    public function testItRendersAuthorizationExceptions()
+    {
+        Route::get('test-route', fn () => Response::deny('expected message', 321)->authorize());
+
+        // HTTP request...
+        $this->get('test-route')
+            ->assertStatus(403)
+            ->assertSeeText('expected message');
+
+        // JSON request...
+        $this->getJson('test-route')
+            ->assertStatus(403)
+            ->assertExactJson([
+                'message' => 'expected message',
+            ]);
+    }
+
+    public function testItRendersAuthorizationExceptionsWithCustomStatusCode()
+    {
+        Route::get('test-route', fn () => Response::deny('expected message', 321)->withStatus(404)->authorize());
+
+        // HTTP request...
+        $this->get('test-route')
+            ->assertStatus(404)
+            ->assertSeeText('Not Found');
+
+        // JSON request...
+        $this->getJson('test-route')
+            ->assertStatus(404)
+            ->assertExactJson([
+                'message' => 'expected message',
+            ]);
+    }
+}


### PR DESCRIPTION
This PR introduces the ability to set the status code for a denied authorization action in policies, gates, and wherever `Auth\Access\Response` or `AuthorizationException` are handled by the framework.

Let's take the following example policy where only the authenticated user can view themselves...

```php
Route::get('users/{user}', fn () => UserResource::make($user))->can('view', 'user');

class UserPolicy
{
    use HandlesAuthorization;

    public function view(User $authenticated, User $user)
    {
        return $authenticated->is($user)
            ? $this->allow()
            : $this->deny();
    }
}
```

Given the above scenario, any user is now able to determine how many users the system currently has if the system is using auto-incrementing IDS...

```php
actingAs($me)->get('users/9991') // 401 😏
actingAs($me)->get('users/9992') // 401 😏
actingAs($me)->get('users/9993') // 404 😮
```

This PR improves (but does not totally solve[**](#note)) this scenario by allowing developers to specify the HTTP response code that should be returned when a "forbidden" action is attempted.

```php
class UserPolicy
{
    use HandlesAuthorization;

    public function view(User $authenticated, User $user)
    {
        return $authenticated->is($user)
            ? $this->allow()
            : $this->deny()->withStatus(404); // response status code
    }
}

actingAs($me)->get('users/9991') // 404 🤔
actingAs($me)->get('users/9992') // 404 🤔
actingAs($me)->get('users/9993') // 404 🤔
```

This is what I would consider a security "best practice". You can see it all across the web. GitHub, for example, will show a `404` for repositories that exist or not when you are not allowed to access them, for example...

[https://github.com/timacdonald/config-differ](https://github.com/timacdonald/config-differ)

The above repository exists...

<img width="631" alt="Screen Shot 2022-06-26 at 4 47 18 pm" src="https://user-images.githubusercontent.com/24803032/175802895-254c2d14-adcd-44db-9d4d-3bccad2bde50.png">

but because it is private, everyone else except for myself will see a `404` response, thus keeping its existence secret.

As you can see from my initial example and then this GitHub example, this feature is not only useful for incrementing IDs, but generally for hiding the existence of any resource[**](#note).

## Full API

Using `Illuminate\Auth\Access\HandlesAuthorization` e.g. Policies...

```php
use HandlesAuthorization;

public function view(User $user, Post $post)
{
    /* ... */

    return $this->deny($message, $code)->withStatus(404);
    
    // or...

    return $this->denyWithStatus(404);
}
```

Returning `Illuminate\Auth\Access\Response` e.g. Gates...

```php
Gate::define('edit-settings', function (User $user) {
    /* ... */

    return Response::deny($message, $code)->withStatus(404);

    // or...

    return Response::denyWithStatus(404);
});
```

Directly throwing the exception....

```php
throw (new AuthorizationException)->withStatus(418);
```

The exception is translated in the exception handler to send the appropriate HTTP status response.

## Why not just use `abort()`

I'm glad you asked! There is an argument to just utilise the `abort` helper here...

```php
public function view(User $user, Post $post)
{
    /* ... */
    
    // return $this->denyWithStatus(404);

    abort(404);
}
```

However this has a few downfalls.

1. It bubbles up a HTTP exception, which means in the exception handler you have lost the context of the exception. Knowing the type of exception can be important for logging and detecting bad actors, threat detection, etc. Having the `AuthorizationException` bubble up to the exception handler allows you to categorize and appropriately handle that _type_ of exception as needed by your application.
2. You lose the ability to specify an exception code. The abort helper allows you to specify a HTTP status code, but not the underlying exception code. status code != exception code. Exception codes are generally utilised on applications as internal mappings to *exact* issues within the application. The following example is how that may be used...

```php
public function view(User $user, Post $post)
{
    /* ... */
    
    if ($user->isInactive()) {
        return $this->deny(Errors::INACTIVE_USER['message'], Errors::INACTIVE_USER['code'])
            ->withStatus(404);
    }

    if ($user->isNotAdmin()) {
        return $this->deny(Errors::NOT_ADMIN['message'], Errors::NOT_ADMIN['code'])
            ->withStatus(404);
    }
    
    // etc...
}
```

This allows developers to handle the exception **type** while logging an exception message, exception code, and translating to an appropriate HTTP status code for security reasons.

## Notes

<a name="note"></a>
- **This PR improves, but does not completely solve the problem, as there is still the possibility of timing attacks.
- It is possible to set the status on an "allow" action, however it is discarded in the same way that the "message" and exception "code" are discarded.