### PR TITLE
`Cache::memo`

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -72,6 +72,25 @@ class CacheManager implements FactoryContract
     }
 
     /**
+     * Get a memoized cache driver instance.
+     *
+     * @param  string|null  $driver
+     * @return \Illuminate\Contracts\Cache\Repository
+     */
+    public function memo($driver = null)
+    {
+        $driver = $driver ?: $this->getDefaultDriver();
+
+        if (! $this->app->bound($bindingKey = "cache.__memoized:{$driver}")) {
+            $this->app->scoped($bindingKey, fn () => $this->repository(
+                new MemoizedStore($driver, $this->store($driver)), ['events' => false]
+            ));
+        }
+
+        return $this->app->make($bindingKey);
+    }
+
+    /**
      * Resolve the given store.
      *
      * @param  string  $name

--- a/src/Illuminate/Cache/MemoizedStore.php
+++ b/src/Illuminate/Cache/MemoizedStore.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace Illuminate\Cache;
+
+use Illuminate\Contracts\Cache\Store;
+
+class MemoizedStore implements Store
+{
+    /**
+     * The memoized cache values.
+     *
+     * @var array<string, mixed>
+     */
+    protected $cache = [];
+
+    /**
+     * Create a new memoized cache instance.
+     *
+     * @param  string  $name
+     * @param  \Illuminate\Cache\Repository  $repository
+     */
+    public function __construct(
+        protected $name,
+        protected $repository,
+    ) {
+        //
+    }
+
+    /**
+     * Retrieve an item from the cache by key.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function get($key)
+    {
+        $prefixedKey = $this->prefix($key);
+
+        if (array_key_exists($prefixedKey, $this->cache)) {
+            return $this->cache[$prefixedKey];
+        }
+
+        return $this->cache[$prefixedKey] = $this->repository->get($key);
+    }
+
+    /**
+     * Retrieve multiple items from the cache by key.
+     *
+     * Items not found in the cache will have a null value.
+     *
+     * @return array
+     */
+    public function many(array $keys)
+    {
+        $memoized = [];
+        $retrieved = [];
+        $missing = [];
+
+        foreach ($keys as $key) {
+            $prefixedKey = $this->prefix($key);
+
+            if (array_key_exists($prefixedKey, $this->cache)) {
+                $memoized[$key] = $this->cache[$prefixedKey];
+            } else {
+                $missing[] = $key;
+            }
+        }
+
+        if (count($missing) > 0) {
+            $retrieved = tap($this->repository->many($missing), function ($values) {
+                $this->cache = [
+                    ...$this->cache,
+                    ...collect($values)->mapWithKeys(fn ($value, $key) => [
+                        $this->prefix($key) => $value,
+                    ]),
+                ];
+            });
+        }
+
+        $result = [
+            ...$memoized,
+            ...$retrieved,
+        ];
+
+        return array_replace(array_flip($keys), $result);
+    }
+
+    /**
+     * Store an item in the cache for a given number of seconds.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  int  $seconds
+     * @return bool
+     */
+    public function put($key, $value, $seconds)
+    {
+        unset($this->cache[$this->prefix($key)]);
+
+        return $this->repository->put($key, $value, $seconds);
+    }
+
+    /**
+     * Store multiple items in the cache for a given number of seconds.
+     *
+     * @param  int  $seconds
+     * @return bool
+     */
+    public function putMany(array $values, $seconds)
+    {
+        foreach ($values as $key => $value) {
+            unset($this->cache[$this->prefix($key)]);
+        }
+
+        return $this->repository->putMany($values, $seconds);
+    }
+
+    /**
+     * Increment the value of an item in the cache.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return int|bool
+     */
+    public function increment($key, $value = 1)
+    {
+        unset($this->cache[$this->prefix($key)]);
+
+        return $this->repository->increment($key, $value);
+    }
+
+    /**
+     * Decrement the value of an item in the cache.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return int|bool
+     */
+    public function decrement($key, $value = 1)
+    {
+        unset($this->cache[$this->prefix($key)]);
+
+        return $this->repository->decrement($key, $value);
+    }
+
+    /**
+     * Store an item in the cache indefinitely.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function forever($key, $value)
+    {
+        unset($this->cache[$this->prefix($key)]);
+
+        return $this->repository->forever($key, $value);
+    }
+
+    /**
+     * Remove an item from the cache.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function forget($key)
+    {
+        unset($this->cache[$this->prefix($key)]);
+
+        return $this->repository->forget($key);
+    }
+
+    /**
+     * Remove all items from the cache.
+     *
+     * @return bool
+     */
+    public function flush()
+    {
+        $this->cache = [];
+
+        return $this->repository->flush();
+    }
+
+    /**
+     * Get the cache key prefix.
+     *
+     * @return string
+     */
+    public function getPrefix()
+    {
+        return $this->repository->getPrefix();
+    }
+
+    /**
+     * Prefix the given key.
+     *
+     * @param  string  $key
+     * @return string
+     */
+    protected function prefix($key)
+    {
+        return $this->getPrefix().$key;
+    }
+}

--- a/src/Illuminate/Cache/MemoizedStore.php
+++ b/src/Illuminate/Cache/MemoizedStore.php
@@ -52,9 +52,7 @@ class MemoizedStore implements Store
      */
     public function many(array $keys)
     {
-        $memoized = [];
-        $retrieved = [];
-        $missing = [];
+        [$memoized, $retrieved, $missing] = [[], [], []];
 
         foreach ($keys as $key) {
             $prefixedKey = $this->prefix($key);

--- a/src/Illuminate/Support/Facades/Cache.php
+++ b/src/Illuminate/Support/Facades/Cache.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support\Facades;
 
 /**
  * @method static \Illuminate\Contracts\Cache\Repository store(string|null $name = null)
+ * @method static \Illuminate\Contracts\Cache\Repository memo(string|null $name = null)
  * @method static \Illuminate\Contracts\Cache\Repository driver(string|null $driver = null)
  * @method static \Illuminate\Contracts\Cache\Repository resolve(string $name)
  * @method static \Illuminate\Cache\Repository build(array $config)

--- a/tests/Integration/Cache/MemoizedStoreTest.php
+++ b/tests/Integration/Cache/MemoizedStoreTest.php
@@ -1,0 +1,382 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Cache;
+
+use Illuminate\Cache\Events\CacheEvent;
+use Illuminate\Cache\Events\CacheMissed;
+use Illuminate\Cache\Events\ForgettingKey;
+use Illuminate\Cache\Events\KeyForgotten;
+use Illuminate\Cache\Events\KeyWritten;
+use Illuminate\Cache\Events\RetrievingKey;
+use Illuminate\Cache\Events\RetrievingManyKeys;
+use Illuminate\Cache\Events\WritingKey;
+use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Redis;
+use Orchestra\Testbench\TestCase;
+
+class MemoizedStoreTest extends TestCase
+{
+    use InteractsWithRedis;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setUpRedis();
+
+        Config::set('cache.default', 'redis');
+        Redis::flushAll();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->tearDownRedis();
+    }
+
+    public function test_it_can_memoize_when_retrieving_single_value()
+    {
+        Cache::put('name', 'Tim', 60);
+
+        $live = Cache::get('name');
+        $memoized = Cache::memo()->get('name');
+        $this->assertSame('Tim', $live);
+        $this->assertSame('Tim', $memoized);
+
+        Cache::put('name', 'Taylor', 60);
+
+        $live = Cache::get('name');
+        $memoized = Cache::memo()->get('name');
+        $this->assertSame('Taylor', $live);
+        $this->assertSame('Tim', $memoized);
+    }
+
+    public function test_null_values_are_memoized_when_retrieving_single_value()
+    {
+        $live = Cache::get('name');
+        $memoized = Cache::memo()->get('name');
+        $this->assertNull($live);
+        $this->assertNull($memoized);
+
+        Cache::put('name', 'Taylor', 60);
+
+        $live = Cache::get('name');
+        $memoized = Cache::memo()->get('name');
+        $this->assertSame('Taylor', $live);
+        $this->assertNull($memoized);
+    }
+
+    public function test_it_can_memoize_when_retrieving_mulitple_values()
+    {
+        Cache::put('name.0', 'Tim', 60);
+        Cache::put('name.1', 'Taylor', 60);
+
+        $live = Cache::getMultiple(['name.0', 'name.1']);
+        $memoized = Cache::memo()->getMultiple(['name.0', 'name.1']);
+        $this->assertSame(['name.0' => 'Tim', 'name.1' => 'Taylor'], $live);
+        $this->assertSame(['name.0' => 'Tim', 'name.1' => 'Taylor'], $memoized);
+
+        Cache::put('name.0', 'MacDonald', 60);
+        Cache::put('name.1', 'Otwell', 60);
+
+        $live = Cache::getMultiple(['name.0', 'name.1']);
+        $memoized = Cache::memo()->getMultiple(['name.0', 'name.1']);
+        $this->assertSame(['name.0' => 'MacDonald', 'name.1' => 'Otwell'], $live);
+        $this->assertSame(['name.0' => 'Tim', 'name.1' => 'Taylor'], $memoized);
+    }
+
+    public function test_null_values_are_memoized_when_retrieving_mulitple_values()
+    {
+        $live = Cache::getMultiple(['name.0', 'name.1']);
+        $memoized = Cache::memo()->getMultiple(['name.0', 'name.1']);
+        $this->assertSame($live, ['name.0' => null, 'name.1' => null]);
+        $this->assertSame($memoized, ['name.0' => null, 'name.1' => null]);
+
+        Cache::put('name.0', 'MacDonald', 60);
+        Cache::put('name.1', 'Otwell', 60);
+
+        $live = Cache::getMultiple(['name.0', 'name.1']);
+        $memoized = Cache::memo()->getMultiple(['name.0', 'name.1']);
+        $this->assertSame($live, ['name.0' => 'MacDonald', 'name.1' => 'Otwell']);
+        $this->assertSame($memoized, ['name.0' => null, 'name.1' => null]);
+    }
+
+    public function test_it_can_retrieve_already_memoized_and_not_yet_memoized_values_when_retrieving_mulitple_values()
+    {
+        Cache::put('name.0', 'Tim', 60);
+        Cache::put('name.1', 'Taylor', 60);
+
+        $live = Cache::get('name.0');
+        $memoized = Cache::memo()->get('name.0');
+        $this->assertSame('Tim', $live);
+        $this->assertSame('Tim', $memoized);
+
+        Cache::put('name.0', 'MacDonald', 60);
+        Cache::put('name.1', 'Otwell', 60);
+
+        $live = Cache::getMultiple(['name.0', 'name.1']);
+        $memoized = Cache::memo()->getMultiple(['name.0', 'name.1']);
+        $this->assertSame(['name.0' => 'MacDonald', 'name.1' => 'Otwell'], $live);
+        $this->assertSame(['name.0' => 'Tim', 'name.1' => 'Otwell'], $memoized);
+    }
+
+    public function test_put_forgets_memoized_value()
+    {
+        Cache::put(['name.0' => 'Tim', 'name.1' => 'Taylor'], 60);
+
+        $live = Cache::get(['name.0', 'name.1']);
+        $memoized = Cache::memo()->get(['name.0', 'name.1']);
+        $this->assertSame(['name.0' => 'Tim', 'name.1' => 'Taylor'], $live);
+        $this->assertSame(['name.0' => 'Tim', 'name.1' => 'Taylor'], $memoized);
+
+        Cache::memo()->put('name.0', 'MacDonald');
+        Cache::memo()->put('name.1', 'Otwell');
+
+        $live = Cache::get(['name.0', 'name.1']);
+        $memoized = Cache::memo()->get(['name.0', 'name.1']);
+        $this->assertSame(['name.0' => 'MacDonald', 'name.1' => 'Otwell'], $live);
+        $this->assertSame(['name.0' => 'MacDonald', 'name.1' => 'Otwell'], $memoized);
+    }
+
+    public function test_put_many_forgets_memoized_value()
+    {
+        Cache::memo()->put(['name.0' => 'Tim', 'name.1' => 'Taylor'], 60);
+
+        $live = Cache::get(['name.0', 'name.1']);
+        $memoized = Cache::memo()->get(['name.0', 'name.1']);
+        $this->assertSame(['name.0' => 'Tim', 'name.1' => 'Taylor'], $live);
+        $this->assertSame(['name.0' => 'Tim', 'name.1' => 'Taylor'], $memoized);
+
+        Cache::memo()->put(['name.0' => 'MacDonald'], 60);
+
+        $live = Cache::get(['name.0', 'name.1']);
+        $memoized = Cache::memo()->get(['name.0', 'name.1']);
+        $this->assertSame(['name.0' => 'MacDonald', 'name.1' => 'Taylor'], $live);
+        $this->assertSame(['name.0' => 'MacDonald', 'name.1' => 'Taylor'], $memoized);
+    }
+
+    public function test_increment_forgets_memoized_value()
+    {
+        Cache::put('count', 1, 60);
+
+        $live = Cache::get('count');
+        $memoized = Cache::memo()->get('count');
+        $this->assertSame('1', $live);
+        $this->assertSame('1', $memoized);
+
+        Cache::memo()->increment('count');
+
+        $live = Cache::get('count');
+        $memoized = Cache::memo()->get('count');
+        $this->assertSame('2', $live);
+        $this->assertSame('2', $memoized);
+    }
+
+    public function test_decrement_forgets_memoized_value()
+    {
+        Cache::put('count', 1, 60);
+
+        $live = Cache::get('count');
+        $memoized = Cache::memo()->get('count');
+        $this->assertSame('1', $live);
+        $this->assertSame('1', $memoized);
+
+        Cache::memo()->decrement('count');
+
+        $live = Cache::get('count');
+        $memoized = Cache::memo()->get('count');
+        $this->assertSame('0', $live);
+        $this->assertSame('0', $memoized);
+    }
+
+    public function test_forever_forgets_memoized_value()
+    {
+        Cache::put('name', 'Tim', 60);
+
+        $live = Cache::get('name');
+        $memoized = Cache::memo()->get('name');
+        $this->assertSame('Tim', $live);
+        $this->assertSame('Tim', $memoized);
+
+        Cache::memo()->forever('name', 'Taylor');
+
+        $live = Cache::get('name');
+        $memoized = Cache::memo()->get('name');
+        $this->assertSame('Taylor', $live);
+        $this->assertSame('Taylor', $memoized);
+    }
+
+    public function test_forget_forgets_memoized_value()
+    {
+        Cache::put('name', 'Tim', 60);
+
+        $live = Cache::get('name');
+        $memoized = Cache::memo()->get('name');
+        $this->assertSame('Tim', $live);
+        $this->assertSame('Tim', $memoized);
+
+        Cache::memo()->forget('name');
+
+        $live = Cache::get('name');
+        $memoized = Cache::memo()->get('name');
+        $this->assertNull($live);
+        $this->assertNull($memoized);
+    }
+
+    public function test_flush_forgets_memoized_value()
+    {
+        Cache::put(['name.0' => 'Tim', 'name.1' => 'Taylor'], 60);
+
+        $live = Cache::get(['name.0', 'name.1']);
+        $memoized = Cache::memo()->get(['name.0', 'name.1']);
+        $this->assertSame(['name.0' => 'Tim', 'name.1' => 'Taylor'], $live);
+        $this->assertSame(['name.0' => 'Tim', 'name.1' => 'Taylor'], $memoized);
+
+        Cache::memo()->flush();
+
+        $live = Cache::get(['name.0', 'name.1']);
+        $memoized = Cache::memo()->get(['name.0', 'name.1']);
+        $this->assertSame(['name.0' => null, 'name.1' => null], $live);
+        $this->assertSame(['name.0' => null, 'name.1' => null], $memoized);
+    }
+
+    public function test_memoized_driver_uses_underlying_drivers_prefix()
+    {
+        $this->assertSame('laravel_cache_', Cache::memo()->getPrefix());
+
+        Cache::driver('redis')->setPrefix('foo');
+
+        $this->assertSame('foo', Cache::memo()->getPrefix());
+    }
+
+    public function test_memoized_keys_are_prefixed()
+    {
+        $redis = Cache::store('redis');
+
+        $redis->setPrefix('aaaa');
+        $redis->put('name', 'Tim', 60);
+        $redis->setPrefix('zzzz');
+        $redis->put('name', 'Taylor', 60);
+
+        $redis->setPrefix('aaaa');
+        $value = Cache::memo('redis')->get('name');
+        $this->assertSame('Tim', $value);
+
+        $redis->setPrefix('zzzz');
+        $value = Cache::memo('redis')->get('name');
+        $this->assertSame('Taylor', $value);
+    }
+
+    public function test_it_dispatches_decorated_driver_events_only()
+    {
+        $redis = Cache::driver('redis');
+        $events = [];
+        Event::listen('*', function ($type, $event) use (&$events) {
+            if ($event[0] instanceof CacheEvent) {
+                $events[] = $event[0];
+            }
+        });
+
+        Cache::memo('redis')->get('name');
+        $this->assertCount(2, $events);
+        $this->assertInstanceOf(RetrievingKey::class, $events[0]);
+        $this->assertSame('redis', $events[0]->storeName);
+        $this->assertSame('name', $events[0]->key);
+        $this->assertInstanceOf(CacheMissed::class, $events[1]);
+        $this->assertSame('redis', $events[1]->storeName);
+        $this->assertSame('name', $events[1]->key);
+        Cache::memo('redis')->get('name');
+        $this->assertCount(2, $events);
+
+        Cache::memo('redis')->many(['name']);
+        $this->assertCount(2, $events);
+
+        Cache::memo('redis')->many(['name.0', 'name.1']);
+        $this->assertCount(5, $events);
+        $this->assertInstanceOf(RetrievingManyKeys::class, $events[2]);
+        $this->assertSame('redis', $events[2]->storeName);
+        $this->assertSame(['name.0', 'name.1'], $events[2]->keys);
+        $this->assertInstanceOf(CacheMissed::class, $events[3]);
+        $this->assertSame('redis', $events[3]->storeName);
+        $this->assertSame('name.0', $events[3]->key);
+        $this->assertInstanceOf(CacheMissed::class, $events[4]);
+        $this->assertSame('redis', $events[4]->storeName);
+        $this->assertSame('name.1', $events[4]->key);
+
+        Cache::memo('redis')->many(['name.0', 'name.1']);
+        $this->assertCount(5, $events);
+
+        Cache::memo('redis')->put('name', 'Tim', 1);
+        $this->assertCount(7, $events);
+        $this->assertInstanceOf(WritingKey::class, $events[5]);
+        $this->assertSame('redis', $events[5]->storeName);
+        $this->assertSame('name', $events[5]->key);
+        $this->assertInstanceOf(KeyWritten::class, $events[6]);
+        $this->assertSame('redis', $events[6]->storeName);
+        $this->assertSame('name', $events[6]->key);
+
+        Cache::memo('redis')->putMany(['name.0' => 'Tim', 'name.1' => 'Taylor']);
+        $this->assertCount(11, $events);
+        $this->assertInstanceOf(WritingKey::class, $events[7]);
+        $this->assertSame('redis', $events[7]->storeName);
+        $this->assertSame('name.0', $events[7]->key);
+        $this->assertInstanceOf(KeyWritten::class, $events[8]);
+        $this->assertSame('redis', $events[8]->storeName);
+        $this->assertSame('name.0', $events[8]->key);
+        $this->assertInstanceOf(WritingKey::class, $events[9]);
+        $this->assertSame('redis', $events[9]->storeName);
+        $this->assertSame('name.1', $events[9]->key);
+        $this->assertInstanceOf(KeyWritten::class, $events[10]);
+        $this->assertSame('redis', $events[10]->storeName);
+        $this->assertSame('name.1', $events[10]->key);
+
+        Cache::memo('redis')->increment('count');
+        $this->assertCount(11, $events);
+
+        Cache::memo('redis')->decrement('count');
+        $this->assertCount(11, $events);
+
+        Cache::memo('redis')->forever('name', 'Taylor');
+        $this->assertCount(13, $events);
+        $this->assertInstanceOf(WritingKey::class, $events[11]);
+        $this->assertSame('redis', $events[11]->storeName);
+        $this->assertSame('name', $events[11]->key);
+        $this->assertInstanceOf(KeyWritten::class, $events[12]);
+        $this->assertSame('redis', $events[12]->storeName);
+        $this->assertSame('name', $events[12]->key);
+
+        Cache::memo('redis')->forget('name');
+        $this->assertCount(15, $events);
+        $this->assertInstanceOf(ForgettingKey::class, $events[13]);
+        $this->assertSame('redis', $events[13]->storeName);
+        $this->assertSame('name', $events[13]->key);
+        $this->assertInstanceOf(KeyForgotten::class, $events[14]);
+        $this->assertSame('redis', $events[14]->storeName);
+        $this->assertSame('name', $events[14]->key);
+
+        Cache::memo('redis')->flush();
+        $this->assertCount(15, $events);
+    }
+
+    public function test_it_resets_cache_store_with_scoped_instances()
+    {
+        Cache::put('name', 'Tim', 60);
+
+        $live = Cache::get('name');
+        $memoized = Cache::memo()->get('name');
+        $this->assertSame('Tim', $live);
+        $this->assertSame('Tim', $memoized);
+
+        Cache::put('name', 'Taylor', 60);
+        $this->app->forgetScopedInstances();
+
+        $live = Cache::get('name');
+        $memoized = Cache::memo()->get('name');
+        $this->assertSame('Taylor', $live);
+        $this->assertSame('Taylor', $memoized);
+    }
+}

--- a/tests/Integration/Cache/RedisStoreTest.php
+++ b/tests/Integration/Cache/RedisStoreTest.php
@@ -21,6 +21,8 @@ class RedisStoreTest extends TestCase
         parent::setUp();
 
         $this->setUpRedis();
+
+        Redis::flushAll();
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
## TODO

- [x] Flush memoized stores for Octane / queue driver.
- [x] Tests for when the underlying driver fails.
- [x] Prefix memoized cache keys.
- [x] Ensure events are dispatched for underlying driver by not the memoized driver.